### PR TITLE
(naoqieus) Add warnings for invalid :volume parameters in :speak

### DIFF
--- a/jsk_naoqi_robot/naoqieus/naoqi-interface.l
+++ b/jsk_naoqi_robot/naoqieus/naoqi-interface.l
@@ -254,12 +254,9 @@
        (setq wait t))
      ;; set volume and language
      (when volume
-       (if (or (> volume 1.0) (< volume 0.0))
-	 (ros::ros-error ":speak :volume ~A must be between 0.0 and 1.0." volume))
        (send self :set-master-volume (round (* volume 100))))
      (when lang
-       (unless (send self :set-language lang)
-         (ros::ros-error ":speak :lang ~A must be English or Japanese" lang)))
+       (send self :set-language lang))
      ;; send speech request
      (send speech_msg :data str)
      (ros::publish (format nil "~A/speech" group-namespace) speech_msg)
@@ -347,10 +344,15 @@
   (:set-master-volume
    (volume)
    (let ((ret (instance nao_interaction_msgs::SetAudioMasterVolumeRequest :init)))
-     (ros::wait-for-service (format nil "~A/naoqi_driver/set_volume" group-namespace))
-     (send ret :master_volume :data volume)
-     (ros::service-call (format nil "~A/naoqi_driver/set_volume" group-namespace) ret)
-     ))
+     (if (<= 0 volume 100)
+	 (progn
+	   (ros::wait-for-service (format nil "~A/naoqi_driver/set_volume" group-namespace))
+	   (send ret :master_volume :data volume)
+	   (ros::service-call (format nil "~A/naoqi_driver/set_volume" group-namespace) ret)
+	   t)
+	 (progn
+	   (ros::ros-error ":set-master-volume ~A must be between 0 and 100." volume)
+	   nil))))
   (:get-master-volume
    ()
    (let ((ret (instance nao_interaction_msgs::GetAudioMasterVolumeRequest :init))
@@ -434,6 +436,8 @@
      (ros::wait-for-service (format nil "~A/naoqi_driver/set_language" group-namespace))
      (send ret :data language)
      (setq res (ros::service-call (format nil "~A/naoqi_driver/set_language" group-namespace) ret))
+     (if (not (send res :success))
+	 (ros::ros-error ":speak :lang ~A must be English or Japanese" language))
      (send res :success))
    )
   (:get-language

--- a/jsk_naoqi_robot/naoqieus/naoqi-interface.l
+++ b/jsk_naoqi_robot/naoqieus/naoqi-interface.l
@@ -254,6 +254,8 @@
        (setq wait t))
      ;; set volume and language
      (when volume
+       (if (or (> volume 1.0) (< volume 0.0))
+	 (ros::ros-error ":speak :volume ~A must be between 0.0 and 1.0." volume))
        (send self :set-master-volume (round (* volume 100))))
      (when lang
        (unless (send self :set-language lang)

--- a/jsk_naoqi_robot/naoqieus/naoqi-interface.l
+++ b/jsk_naoqi_robot/naoqieus/naoqi-interface.l
@@ -254,9 +254,11 @@
        (setq wait t))
      ;; set volume and language
      (when volume
-       (send self :set-master-volume (round (* volume 100))))
+       (unless (send self :set-master-volume (round (* volume 100)))
+         (error "Invalid volume argument")))
      (when lang
-       (send self :set-language lang))
+       (unless (send self :set-language lang)
+         (error "Invalid language argument")))
      ;; send speech request
      (send speech_msg :data str)
      (ros::publish (format nil "~A/speech" group-namespace) speech_msg)
@@ -437,7 +439,7 @@
      (send ret :data language)
      (setq res (ros::service-call (format nil "~A/naoqi_driver/set_language" group-namespace) ret))
      (if (not (send res :success))
-	 (ros::ros-error ":speak :lang ~A must be English or Japanese" language))
+         (ros::ros-error ":speak :lang ~A must be English or Japanese" language))
      (send res :success))
    )
   (:get-language


### PR DESCRIPTION
I need this warning because I often set 0-100 value (not 0.0-1.0) to `:volume`.

```
2.irteusgl$ send *ri* :speak "Hello hello hello hello hello" :volume 30
[ERROR] [1661159591.572453014]: :speak :volume 30 must be between 0.0 and 1.0.
[ INFO] [1661159591.583059851]: subscribing speech_status
[ INFO] [1661159592.082373960]: subscribing speech_status
[ INFO] [1661159592.582496032]: subscribing speech_status
[ INFO] [1661159593.082301666]: subscribing speech_status
[ INFO] [1661159593.582423912]: subscribing speech_status
[ INFO] [1661159594.082312257]: subscribing speech_status
t
```